### PR TITLE
fix: Allow recommendationId to be null

### DIFF
--- a/src/RecommendationQuery.php
+++ b/src/RecommendationQuery.php
@@ -147,10 +147,6 @@ class RecommendationQuery extends AbstractQuery implements MachineLearningSuppor
     {
         parent::verify();
 
-        if (null === $this->recommendationId) {
-            throw new DomainException('recommendationId: (identifier) must be set!');
-        }
-
         if (null === $this->count) {
             throw new DomainException('count: must be set!');
         }


### PR DESCRIPTION
Solves [MAKAIRA-3656](https://youtrack.marmalade.group/issue/MAKAIRA-3656/Preview-is-not-working-in-creation-mode-of-a-reco)