### PR TITLE
fix: Mandatory constraints don't allow empty string

### DIFF
--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -69,7 +69,7 @@ abstract class AbstractQuery extends DataObject
     public function verify()
     {
         foreach ($this->getMandatoryConstraints() as $key => $label) {
-            if (!isset($this->constraints[$key])) {
+            if (!$this->isConstraintExists($key)) {
                 throw new DomainException(sprintf('Missing mandatory %s constraint.', $label));
             }
         }
@@ -115,5 +115,18 @@ abstract class AbstractQuery extends DataObject
         return (new static($data))
             ->verify()
             ->filterConstraints();
+    }
+
+    private function isConstraintExists($key)
+    {
+        if (!isset($this->constraints[$key])) {
+            return false;
+        }
+
+        if ('' === $this->constraints[$key]) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -69,7 +69,7 @@ abstract class AbstractQuery extends DataObject
     public function verify()
     {
         foreach ($this->getMandatoryConstraints() as $key => $label) {
-            if (!$this->isConstraintExists($key)) {
+            if (empty($this->constraints[$key])) {
                 throw new DomainException(sprintf('Missing mandatory %s constraint.', $label));
             }
         }
@@ -115,18 +115,5 @@ abstract class AbstractQuery extends DataObject
         return (new static($data))
             ->verify()
             ->filterConstraints();
-    }
-
-    private function isConstraintExists($key)
-    {
-        if (!isset($this->constraints[$key])) {
-            return false;
-        }
-
-        if ('' === $this->constraints[$key]) {
-            return false;
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
Solves [MAKAIRA-4359](https://youtrack.marmalade.group/issue/MAKAIRA-4359/Empty-shop-requests-are-not-kept-by-the-Makaira-API)