### PR TITLE
fix: Stop applying array_filter on request aggregation

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -138,7 +138,8 @@ class Query extends AbstractQuery
      */
     public function sanitize()
     {
-        $this->aggregations = array_filter($this->aggregations);
+        // This was commented out because array filter will also remove 0, and we do not want this
+        // $this->aggregations = array_filter($this->aggregations);
 
         return $this;
     }


### PR DESCRIPTION
Solves [MAKAIRA-4465](https://youtrack.marmalade.group/issue/MAKAIRA-4465) Range slider filter is ignore if max selected value is equal to the min value