### PR TITLE
fix: remove null and empty string values from the request aggregation

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -138,8 +138,9 @@ class Query extends AbstractQuery
      */
     public function sanitize()
     {
-        // This was commented out because array filter will also remove 0, and we do not want this
-        // $this->aggregations = array_filter($this->aggregations);
+        $this->aggregations = array_filter($this->aggregations, static function ($value) {
+            return $value !== null && $value !== '';
+        });
 
         return $this;
     }


### PR DESCRIPTION
Solves [MAKAIRA-4465](https://youtrack.marmalade.group/issue/MAKAIRA-4465) Range slider filter is ignore if max selected value is equal to the min value